### PR TITLE
update to most recent angular

### DIFF
--- a/generators/app/templates/src/index2.html
+++ b/generators/app/templates/src/index2.html
@@ -17,7 +17,7 @@
     <!-- scripts -->
     <script type="text/javascript" src="//code.jquery.com/jquery-2.2.4.min.js"></script>
     <script type="text/javascript" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.js"></script>
     <script type="text/javascript" src="js/app.js"></script>
     <script type="text/javascript" src="js/config.js"></script>
     <!-- main component -->


### PR DESCRIPTION
Google CDN didn't seem to have a link for 1.5.8, so I grabbed one from CDNJS.